### PR TITLE
Return string

### DIFF
--- a/bench.exs
+++ b/bench.exs
@@ -1,0 +1,7 @@
+Benchee.run(
+  %{
+    "2 ^ 2" => fn -> MPDecimal.Nif.power("2", "2") end,
+    "2.0 ^ 2.0" => fn -> MPDecimal.Nif.power("2.0", "2.0") end,
+    "3.14159 ^ 1.58732" => fn -> MPDecimal.Nif.power("3.14159", "1.58732") end
+  }
+)

--- a/bench.exs
+++ b/bench.exs
@@ -1,7 +1,0 @@
-Benchee.run(
-  %{
-    "2 ^ 2" => fn -> MPDecimal.Nif.power("2", "2") end,
-    "2.0 ^ 2.0" => fn -> MPDecimal.Nif.power("2.0", "2.0") end,
-    "3.14159 ^ 1.58732" => fn -> MPDecimal.Nif.power("3.14159", "1.58732") end
-  }
-)

--- a/bench/decimal_comparison.exs
+++ b/bench/decimal_comparison.exs
@@ -1,0 +1,11 @@
+two = Decimal.new("2.0")
+
+Benchee.run(
+  %{
+    "2.0 + 2.0" => fn -> Decimal.add(two, two) end,
+    "2.0 * 2.0" => fn -> Decimal.mult(two, two) end,
+    "2.0 ^ 2.0" => fn -> MPDecimal.power(two, two) end
+  },
+  warmup: 1,
+  time: 2
+)

--- a/bench/decimal_comparison.exs
+++ b/bench/decimal_comparison.exs
@@ -1,11 +1,18 @@
-two = Decimal.new("2.0")
+base0 =  Decimal.new("4.0")
+power0 = Decimal.new("0.5")
+
+base1 =  Decimal.new("1234567890.1234567890123456")
+power1 = Decimal.new("0.1234567890123456789012345")
 
 Benchee.run(
   %{
-    "2.0 + 2.0" => fn -> Decimal.add(two, two) end,
-    "2.0 * 2.0" => fn -> Decimal.mult(two, two) end,
-    "2.0 ^ 2.0" => fn -> MPDecimal.power(two, two) end
+    "Decimal.sqrt(\"4.0\")" => fn -> Decimal.sqrt(base0) end,
+    "Decimal.sqrt(\"1234567890.1234567890123456\")" => fn -> Decimal.sqrt(base1) end,
+    "MPDecimal.power(\"4.0\",\"0.5\")" => fn -> MPDecimal.power(base0, power0) end,
+    "MPDecimal.power(\"1234567890.1234567890123456\",\"0.5\")" => fn -> MPDecimal.power(base1, power0) end,
+    "MPDecimal.power(\"1234567890.1234567890123456\",\"0.1234567890123456789012345\")" => fn -> MPDecimal.power(base1, power1) end
+    
   },
   warmup: 1,
-  time: 2
+  time: 2 
 )

--- a/bench/raw_nif_calls.exs
+++ b/bench/raw_nif_calls.exs
@@ -1,0 +1,11 @@
+Benchee.run(
+  %{
+    "2 ^ 2" => fn -> MPDecimal.Nif.power("2", "2") end,
+    "2.0 ^ 2.0" => fn -> MPDecimal.Nif.power("2.0", "2.0") end,
+    "9.0 ^ 0.5" => fn -> MPDecimal.Nif.power("9.0", "0.5") end,
+    "3.14159 ^ 1.58732" => fn -> MPDecimal.Nif.power("3.14159", "1.58732") end,
+    "3.14159 ^ 1234.58732" => fn -> MPDecimal.Nif.power("3.14159", "1234.58732") end
+  },
+  warmup: 1,
+  time: 2
+)

--- a/c_src/mpdecimal_nif.c
+++ b/c_src/mpdecimal_nif.c
@@ -15,10 +15,24 @@
 static mpd_context_t ctx;
 
 static int load(ErlNifEnv *env, void **priv_data, ERL_NIF_TERM load_info) {
-  mpd_init(&ctx, 28);
+	// TODO: Because the MPD context is persistent, status flags and error
+	// conditions will accumulate across multiple calls into this library. Do we
+	// need to do maintenance of any kind on these flags?
+	mpd_init(&ctx, 28);
 	ctx.traps = 0;
   return 0;
 }
+
+#ifdef NIF_DEBUG
+static void printf_data_hex(const unsigned char* data, size_t size)
+{
+	const unsigned char* end = data + size;
+	while (data < end) {
+		printf("0x%02x ", *(data++));
+	}
+	printf("\r\n");
+}
+#endif
 
 static ERL_NIF_TERM mpdecimal_power(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[])
 {
@@ -30,84 +44,101 @@ static ERL_NIF_TERM mpdecimal_power(ErlNifEnv *env, int argc, const ERL_NIF_TERM
   ErlNifBinary power;
   ERL_NIF_TERM return_value;
 
-  if(argc != 2 ||
-    !enif_is_binary(env, argv[0]) ||
-    !enif_is_binary(env, argv[1])) {
+	// Convert parameters into Erlang binaries.
+  if (argc != 2 ||
+		  !enif_inspect_binary(env, argv[0], &base) ||
+		  !enif_inspect_binary(env, argv[1], &power)) {
     return enif_make_badarg(env);
   }
 
-  #ifdef NIF_DEBUG
-  enif_fprintf(stdout, "base  (as binary): %T\r\n", argv[0]);
-  enif_fprintf(stdout, "power (as binary): %T\r\n", argv[1]);
-  #endif
+#ifdef NIF_DEBUG
+	printf("----Parameters----\r\n");
+  enif_fprintf(stdout, "base (binary): %T\r\n", argv[0]);
+	printf("  - size: %zu\r\n", base.size);
+	printf("  - encoding: ");
+	printf_data_hex(base.data, base.size);
 
-  // convert elixir string arguments into mpdecimal structs
-  enif_inspect_binary(env, argv[0], &base);
-  enif_inspect_binary(env, argv[1], &power);
+  enif_fprintf(stdout, "power (binary): %T\r\n", argv[1]);
+	printf("  - size: %zu\r\n", power.size);
+	printf("  - encoding: ");
+	printf_data_hex(power.data, power.size);
+#endif
 
-  #ifdef NIF_DEBUG
-  fprintf(stdout, "base  (as cstring): %s\r\n  - binary size: %d\r\n  - cstring strlen: %d\r\n", base.data, base.size, strlen(base.data));
-  fprintf(stdout, "power (as cstring): %s\r\n  - binary size: %d\r\n  - cstring strlen: %d\r\n", power.data, power.size, strlen(power.data));
-
-	fprintf(stdout, "base encoding:  ");
-	unsigned char* index = base.data;
-	do {
-		fprintf(stdout, "0x%02x ", *index);
-	} while (*(index++) != 0);
-	fprintf(stdout, "\r\n");
-
-	fprintf(stdout, "power encoding: ");
-	index = power.data;
-	do {
-		fprintf(stdout, "0x%02x ", *index);
-	} while (*(index++) != 0);
-	fprintf(stdout, "\r\n");
-  #endif
-
+#ifdef NIF_DEBUG
+	printf("\r\n----Converting parameters from Erlang binary to cstring----\r\n");
+#endif
 	// This relies on the property that the Erlang binary encoding uses only
 	// single-byte ASCII-compatible values.
 	// 
-	// TODO: Check whether the source of this data (Elixir Decimal library)
-	// guarantees this property.
-	char* base_cstring = (char*) malloc((base.size + 1)*sizeof(char));
-	char* power_cstring = (char*) malloc((power.size + 1)*sizeof(char));
-	strncpy(base_cstring, base.data, base.size);
-	strncpy(power_cstring, power.data, power.size);
+	// TODO: Add checks to validate that the string contains only valid ASCII
+	// characters. (i.e. Assert that the above property is true.)
+	//
+	// Allocate the same number of bytes as used by the Erlang binary, plus one
+	// for the null terminator.
+	char* base_cstring = (char*) enif_alloc((base.size + 1)*sizeof(char));
+	char* power_cstring = (char*) enif_alloc((power.size + 1)*sizeof(char));
+	strncpy(base_cstring, (char*) base.data, base.size);
+	strncpy(power_cstring, (char*) power.data, power.size);
+	// Manually add null terminator to each string.
+	base_cstring[base.size] = '\0';
+	power_cstring[power.size] = '\0';
 
+#ifdef NIF_DEBUG
+	printf("base (cstring):  %s\r\n", base_cstring);
+	printf("  - encoding: ");
+	printf_data_hex((unsigned char*) base_cstring, base.size + 1);
+	printf("power (cstring): %s\r\n", power_cstring);
+	printf("  - encoding: ");
+	printf_data_hex((unsigned char*) power_cstring, power.size + 1);
+#endif
+
+#ifdef NIF_DEBUG
+	printf("\r\n----Converting parameters from cstring to mpd----\r\n");
+	mpd_snprint_flags(status_str, MPD_MAX_FLAG_STRING, ctx.status);
+	printf("Inital mpd status: %s\r\n", status_str);
+#endif
   a = mpd_new(&ctx);
 	b = mpd_new(&ctx);
 	mpd_set_string(a, base_cstring, &ctx);
-	mpd_set_string(b, power_cstring, &ctx);
-
-  #ifdef NIF_DEBUG
+#ifdef NIF_DEBUG
+	mpd_snprint_flags(status_str, MPD_MAX_FLAG_STRING, ctx.status);
   rstring = mpd_to_sci(a, 1);
-  enif_fprintf(stdout, "mpd base: %s\r\n", rstring);
+  printf("base (mpd):   %s\r\n", rstring);
+	printf("  - status: %s\r\n", status_str);
+#endif
+	mpd_set_string(b, power_cstring, &ctx);
+#ifdef NIF_DEBUG
+	mpd_snprint_flags(status_str, MPD_MAX_FLAG_STRING, ctx.status);
   rstring = mpd_to_sci(b, 1);
-  enif_fprintf(stdout, "mpd power: %s\r\n", rstring);
-  #endif
+  printf("power (mpd):  %s\r\n", rstring);
+	printf("  - status: %s\r\n", status_str);
+#endif
 
-  // run the calculation
+#ifdef NIF_DEBUG
+	printf("\r\n----Perfoming the calculation----\r\n");
+#endif
   result = mpd_new(&ctx);
 	mpd_pow(result, a, b, &ctx);
 
-  // convert result to an elixir string
+  // Convert result to cstring.
 	rstring = mpd_to_sci(result, 1);
-  #ifdef NIF_DEBUG
-  enif_fprintf(stdout, "mpd result: %s\r\n", rstring);
-  #endif
+#ifdef NIF_DEBUG
+  printf("result (mpd): %s\r\n", rstring);
 	mpd_snprint_flags(status_str, MPD_MAX_FLAG_STRING, ctx.status);
+	printf("  - status: %s\r\n", status_str);
+#endif
   unsigned char* bin_ptr = enif_make_new_binary(env, strlen(rstring), &return_value);
-  strcpy(bin_ptr, rstring);
+  memcpy(bin_ptr, rstring, strlen(rstring));
 
-  // cleanup mpdecimal memory
+  // Clean up mpdecimal memory.
 	mpd_del(a);
 	mpd_del(b);
 	mpd_del(result);
 	mpd_free(rstring);
 
-	// Clean up locally-used memory.
-	free(base_cstring);
-	free(power_cstring);
+	// Clean up memory that was allocated locally.
+	enif_free(base_cstring);
+	enif_free(power_cstring);
 	
 	return return_value;
 }

--- a/c_src/mpdecimal_nif.c
+++ b/c_src/mpdecimal_nif.c
@@ -64,10 +64,20 @@ static ERL_NIF_TERM mpdecimal_power(ErlNifEnv *env, int argc, const ERL_NIF_TERM
 	} while (*(index++) != 0);
 	fprintf(stdout, "\r\n");
 
+	// This relies on the property that the Erlang binary encoding uses only
+	// single-byte ASCII-compatible values.
+	// 
+	// TODO: Check whether the source of this data (Elixir Decimal library)
+	// guarantees this property.
+	char* base_cstring = (char*) malloc((base.size + 1)*sizeof(char));
+	char* power_cstring = (char*) malloc((power.size + 1)*sizeof(char));
+	strncpy(base_cstring, base.data, base.size);
+	strncpy(power_cstring, power.data, power.size);
+
   a = mpd_new(&ctx);
 	b = mpd_new(&ctx);
-	mpd_set_string(a, base.data, &ctx);
-	mpd_set_string(b, power.data, &ctx);
+	mpd_set_string(a, base_cstring, &ctx);
+	mpd_set_string(b, power_cstring, &ctx);
 
   // run the calculation
   result = mpd_new(&ctx);
@@ -85,6 +95,10 @@ static ERL_NIF_TERM mpdecimal_power(ErlNifEnv *env, int argc, const ERL_NIF_TERM
 	mpd_del(result);
 	mpd_free(rstring);
 
+	// Clean up locally-used memory.
+	free(base_cstring);
+	free(power_cstring);
+	
 	return return_value;
 }
 

--- a/c_src/mpdecimal_nif.c
+++ b/c_src/mpdecimal_nif.c
@@ -41,14 +41,29 @@ static ERL_NIF_TERM mpdecimal_power(ErlNifEnv *env, int argc, const ERL_NIF_TERM
     return enif_make_badarg(env);
   }
 
-  enif_fprintf(stdout, "base: %T\n", argv[0]);
-  enif_fprintf(stdout, "power: %T\n", argv[1]);
+  enif_fprintf(stdout, "base: %T\r\n", argv[0]);
+  enif_fprintf(stdout, "power: %T\r\n", argv[1]);
 
   // convert elixir string arguments into mpdecimal structs
   enif_inspect_binary(env, argv[0], &base);
   enif_inspect_binary(env, argv[1], &power);
-  printf("base: %s\n\tsize: %d\n\tstrlen: %d\n", base.data, base.size, strlen(base.data));
-  printf("power: %s\n\tsize: %d\n\tstrlen: %d\n", power.data, power.size, strlen(power.data));
+  fprintf(stdout, "base: %s\r\n  - size: %d\r\n  - strlen: %d\r\n", base.data, base.size, strlen(base.data));
+  fprintf(stdout, "power: %s\r\n\tsize: %d\r\n\tstrlen: %d\r\n", power.data, power.size, strlen(power.data));
+
+	fprintf(stdout, "base: ");
+	unsigned char* index = base.data;
+	do {
+		fprintf(stdout, "0x%2x ", *index);
+	} while (*(index++) != '0');
+	fprintf(stdout, "\r\n");
+
+	fprintf(stdout, "power: ");
+	index = power.data;
+	do {
+		fprintf(stdout, "0x%2x ", *index);
+	} while (*(index++) != '0');
+	fprintf(stdout, "\r\n");
+
   a = mpd_new(&ctx);
 	b = mpd_new(&ctx);
 	mpd_set_string(a, base.data, &ctx);

--- a/c_src/mpdecimal_nif.c
+++ b/c_src/mpdecimal_nif.c
@@ -20,41 +20,46 @@ static ERL_NIF_TERM mpdecimal_zero(ErlNifEnv *env, int argc, const ERL_NIF_TERM 
 static ERL_NIF_TERM mpdecimal_power(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[])
 {
   mpd_context_t ctx;
-	mpd_t *a, *b;
+  mpd_t *a, *b;
 	mpd_t *result;
 	char *rstring;
 	char status_str[MPD_MAX_FLAG_STRING];
-
   ErlNifBinary base;
   ErlNifBinary power;
+  ERL_NIF_TERM return_value;
 
+  // convert elixir string arguments into mpdecimal structs
   enif_inspect_binary(env, argv[0], &base);
   enif_inspect_binary(env, argv[1], &power);
 
   printf("%s ^ %s\n", base.data, power.data);
 
-  //printf("%Xull  %XXull  %XXull\n", env, argv[0].env, argv[1].env);
-
-	mpd_init(&ctx, 28);
+  // setup context
+  mpd_init(&ctx, 28);
 	ctx.traps = 0;
-
-	result = mpd_new(&ctx);
-	a = mpd_new(&ctx);
+  a = mpd_new(&ctx);
 	b = mpd_new(&ctx);
 	mpd_set_string(a, base.data, &ctx);
 	mpd_set_string(b, power.data, &ctx);
+
+  // run the calculation
+  result = mpd_new(&ctx);
 	mpd_pow(result, a, b, &ctx);
 
+  // convert result to an elixir string
 	rstring = mpd_to_sci(result, 1);
 	mpd_snprint_flags(status_str, MPD_MAX_FLAG_STRING, ctx.status);
 	printf("%s  %s\n", rstring, status_str);
+  unsigned char* bin_ptr = enif_make_new_binary(env, strlen(rstring), &return_value);
+  strcpy(bin_ptr, rstring);
 
+  // cleanup mpdecimal memory
 	mpd_del(a);
 	mpd_del(b);
 	mpd_del(result);
 	mpd_free(rstring);
 
-	return enif_make_int(env, 0);
+	return return_value;
 }
 
 static ErlNifFunc nif_funcs[] = {

--- a/c_src/mpdecimal_nif.c
+++ b/c_src/mpdecimal_nif.c
@@ -31,10 +31,6 @@ static ERL_NIF_TERM mpdecimal_power(ErlNifEnv *env, int argc, const ERL_NIF_TERM
   // convert elixir string arguments into mpdecimal structs
   enif_inspect_binary(env, argv[0], &base);
   enif_inspect_binary(env, argv[1], &power);
-
-  printf("%s ^ %s\n", base.data, power.data);
-
-  // setup context
   mpd_init(&ctx, 28);
 	ctx.traps = 0;
   a = mpd_new(&ctx);
@@ -49,7 +45,6 @@ static ERL_NIF_TERM mpdecimal_power(ErlNifEnv *env, int argc, const ERL_NIF_TERM
   // convert result to an elixir string
 	rstring = mpd_to_sci(result, 1);
 	mpd_snprint_flags(status_str, MPD_MAX_FLAG_STRING, ctx.status);
-	printf("%s  %s\n", rstring, status_str);
   unsigned char* bin_ptr = enif_make_new_binary(env, strlen(rstring), &return_value);
   strcpy(bin_ptr, rstring);
 

--- a/c_src/mpdecimal_nif.c
+++ b/c_src/mpdecimal_nif.c
@@ -10,6 +10,14 @@
 
 #include "mpdecimal.h"
 
+static mpd_context_t ctx;
+
+static int load(ErlNifEnv *env, void **priv_data, ERL_NIF_TERM load_info) {
+  mpd_init(&ctx, 28);
+	ctx.traps = 0;
+  return 0;
+}
+
 static ERL_NIF_TERM mpdecimal_zero(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[])
 {
   const char* version = mpd_version();
@@ -19,7 +27,6 @@ static ERL_NIF_TERM mpdecimal_zero(ErlNifEnv *env, int argc, const ERL_NIF_TERM 
 
 static ERL_NIF_TERM mpdecimal_power(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[])
 {
-  mpd_context_t ctx;
   mpd_t *a, *b;
 	mpd_t *result;
 	char *rstring;
@@ -31,8 +38,6 @@ static ERL_NIF_TERM mpdecimal_power(ErlNifEnv *env, int argc, const ERL_NIF_TERM
   // convert elixir string arguments into mpdecimal structs
   enif_inspect_binary(env, argv[0], &base);
   enif_inspect_binary(env, argv[1], &power);
-  mpd_init(&ctx, 28);
-	ctx.traps = 0;
   a = mpd_new(&ctx);
 	b = mpd_new(&ctx);
 	mpd_set_string(a, base.data, &ctx);
@@ -63,4 +68,4 @@ static ErlNifFunc nif_funcs[] = {
   {"zero", 0, mpdecimal_zero}
 };
 
-ERL_NIF_INIT(Elixir.MPDecimal.Nif, nif_funcs, NULL, NULL, NULL, NULL)
+ERL_NIF_INIT(Elixir.MPDecimal.Nif, nif_funcs, load, NULL, NULL, NULL)

--- a/c_src/mpdecimal_nif.c
+++ b/c_src/mpdecimal_nif.c
@@ -6,7 +6,7 @@
 #include <unistd.h>
 #endif
 
-#define NIF_DEBUG
+// #define NIF_DEBUG
 
 #include "erl_nif.h"
 
@@ -39,7 +39,9 @@ static ERL_NIF_TERM mpdecimal_power(ErlNifEnv *env, int argc, const ERL_NIF_TERM
   mpd_t *a, *b;
 	mpd_t *result;
 	char *rstring;
+#ifdef NIF_DEBUG
 	char status_str[MPD_MAX_FLAG_STRING];
+#endif
   ErlNifBinary base;
   ErlNifBinary power;
   ERL_NIF_TERM return_value;

--- a/c_src/mpdecimal_nif.c
+++ b/c_src/mpdecimal_nif.c
@@ -35,9 +35,20 @@ static ERL_NIF_TERM mpdecimal_power(ErlNifEnv *env, int argc, const ERL_NIF_TERM
   ErlNifBinary power;
   ERL_NIF_TERM return_value;
 
+  if(argc != 2 ||
+    !enif_is_binary(env, argv[0]) ||
+    !enif_is_binary(env, argv[1])) {
+    return enif_make_badarg(env);
+  }
+
+  enif_fprintf(stdout, "base: %T\n", argv[0]);
+  enif_fprintf(stdout, "power: %T\n", argv[1]);
+
   // convert elixir string arguments into mpdecimal structs
   enif_inspect_binary(env, argv[0], &base);
   enif_inspect_binary(env, argv[1], &power);
+  printf("base: %s\n\tsize: %d\n\tstrlen: %d\n", base.data, base.size, strlen(base.data));
+  printf("power: %s\n\tsize: %d\n\tstrlen: %d\n", power.data, power.size, strlen(power.data));
   a = mpd_new(&ctx);
 	b = mpd_new(&ctx);
 	mpd_set_string(a, base.data, &ctx);

--- a/c_src/mpdecimal_nif.c
+++ b/c_src/mpdecimal_nif.c
@@ -41,27 +41,27 @@ static ERL_NIF_TERM mpdecimal_power(ErlNifEnv *env, int argc, const ERL_NIF_TERM
     return enif_make_badarg(env);
   }
 
-  enif_fprintf(stdout, "base: %T\r\n", argv[0]);
-  enif_fprintf(stdout, "power: %T\r\n", argv[1]);
+  enif_fprintf(stdout, "base  (as binary): %T\r\n", argv[0]);
+  enif_fprintf(stdout, "power (as binary): %T\r\n", argv[1]);
 
   // convert elixir string arguments into mpdecimal structs
   enif_inspect_binary(env, argv[0], &base);
   enif_inspect_binary(env, argv[1], &power);
-  fprintf(stdout, "base: %s\r\n  - size: %d\r\n  - strlen: %d\r\n", base.data, base.size, strlen(base.data));
-  fprintf(stdout, "power: %s\r\n\tsize: %d\r\n\tstrlen: %d\r\n", power.data, power.size, strlen(power.data));
+  fprintf(stdout, "base  (as cstring): %s\r\n  - binary size: %d\r\n  - cstring strlen: %d\r\n", base.data, base.size, strlen(base.data));
+  fprintf(stdout, "power (as cstring): %s\r\n  - binary size: %d\r\n  - cstring strlen: %d\r\n", power.data, power.size, strlen(power.data));
 
-	fprintf(stdout, "base: ");
+	fprintf(stdout, "base encoding:  ");
 	unsigned char* index = base.data;
 	do {
-		fprintf(stdout, "0x%2x ", *index);
-	} while (*(index++) != '0');
+		fprintf(stdout, "0x%02x ", *index);
+	} while (*(index++) != 0);
 	fprintf(stdout, "\r\n");
 
-	fprintf(stdout, "power: ");
+	fprintf(stdout, "power encoding: ");
 	index = power.data;
 	do {
-		fprintf(stdout, "0x%2x ", *index);
-	} while (*(index++) != '0');
+		fprintf(stdout, "0x%02x ", *index);
+	} while (*(index++) != 0);
 	fprintf(stdout, "\r\n");
 
   a = mpd_new(&ctx);

--- a/c_src/mpdecimal_nif.c
+++ b/c_src/mpdecimal_nif.c
@@ -17,8 +17,49 @@ static ERL_NIF_TERM mpdecimal_zero(ErlNifEnv *env, int argc, const ERL_NIF_TERM 
   return enif_make_int(env, 0);
 }
 
+static ERL_NIF_TERM mpdecimal_power(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[])
+{
+  mpd_context_t ctx;
+	mpd_t *a, *b;
+	mpd_t *result;
+	char *rstring;
+	char status_str[MPD_MAX_FLAG_STRING];
+
+  ErlNifBinary base;
+  ErlNifBinary power;
+
+  enif_inspect_binary(env, argv[0], &base);
+  enif_inspect_binary(env, argv[1], &power);
+
+  printf("%s ^ %s\n", base.data, power.data);
+
+  //printf("%Xull  %XXull  %XXull\n", env, argv[0].env, argv[1].env);
+
+	mpd_init(&ctx, 28);
+	ctx.traps = 0;
+
+	result = mpd_new(&ctx);
+	a = mpd_new(&ctx);
+	b = mpd_new(&ctx);
+	mpd_set_string(a, base.data, &ctx);
+	mpd_set_string(b, power.data, &ctx);
+	mpd_pow(result, a, b, &ctx);
+
+	rstring = mpd_to_sci(result, 1);
+	mpd_snprint_flags(status_str, MPD_MAX_FLAG_STRING, ctx.status);
+	printf("%s  %s\n", rstring, status_str);
+
+	mpd_del(a);
+	mpd_del(b);
+	mpd_del(result);
+	mpd_free(rstring);
+
+	return enif_make_int(env, 0);
+}
+
 static ErlNifFunc nif_funcs[] = {
   // {erl_function_name, erl_function_arity, c_function}
+  {"power", 2, mpdecimal_power},
   {"zero", 0, mpdecimal_zero}
 };
 

--- a/lib/mpdecimal.ex
+++ b/lib/mpdecimal.ex
@@ -1,3 +1,2 @@
 defmodule MPDecimal do
-  defdelegate zero, to: MPDecimal.Nif
 end

--- a/lib/mpdecimal.ex
+++ b/lib/mpdecimal.ex
@@ -1,2 +1,10 @@
 defmodule MPDecimal do
+  alias MPDecimal.Nif
+
+  def power(%Decimal{} = base, %Decimal{} = power) do
+    base = Decimal.to_string(base, :xsd)
+    power = Decimal.to_string(power, :xsd)
+    res = Nif.power(base, power)
+    Decimal.new(res)
+  end
 end

--- a/lib/mpdecimal/nif.ex
+++ b/lib/mpdecimal/nif.ex
@@ -19,7 +19,11 @@ defmodule MPDecimal.Nif do
     :erlang.load_nif(path, 0)
   end
 
+  def power(_base, _power) do
+    raise "NIF power/2 not implemented"
+  end
+
   def zero do
-    raise "NIF mpdecimal_zero/0 not implemented"
+    raise "NIF zero/0 not implemented"
   end
 end

--- a/lib/mpdecimal/nif.ex
+++ b/lib/mpdecimal/nif.ex
@@ -22,8 +22,4 @@ defmodule MPDecimal.Nif do
   def power(_base, _power) do
     raise "NIF power/2 not implemented"
   end
-
-  def zero do
-    raise "NIF zero/0 not implemented"
-  end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -23,6 +23,7 @@ defmodule Mpdecimal.MixProject do
 
   defp deps do
     [
+      {:decimal, "~> 2.0"},
       {:elixir_make, "~> 0.6", runtime: false},
       {:benchee, "~> 1.0", only: :dev},
     ]

--- a/mix.exs
+++ b/mix.exs
@@ -24,6 +24,7 @@ defmodule Mpdecimal.MixProject do
   defp deps do
     [
       {:elixir_make, "~> 0.6", runtime: false},
+      {:benchee, "~> 1.0", only: :dev},
     ]
   end
 end

--- a/mix.lock
+++ b/mix.lock
@@ -1,5 +1,6 @@
 %{
   "benchee": {:hex, :benchee, "1.0.1", "66b211f9bfd84bd97e6d1beaddf8fc2312aaabe192f776e8931cb0c16f53a521", [:mix], [{:deep_merge, "~> 1.0", [hex: :deep_merge, repo: "hexpm", optional: false]}], "hexpm", "3ad58ae787e9c7c94dd7ceda3b587ec2c64604563e049b2a0e8baafae832addb"},
+  "decimal": {:hex, :decimal, "2.0.0", "a78296e617b0f5dd4c6caf57c714431347912ffb1d0842e998e9792b5642d697", [:mix], [], "hexpm", "34666e9c55dea81013e77d9d87370fe6cb6291d1ef32f46a1600230b1d44f577"},
   "deep_merge": {:hex, :deep_merge, "1.0.0", "b4aa1a0d1acac393bdf38b2291af38cb1d4a52806cf7a4906f718e1feb5ee961", [:mix], [], "hexpm", "ce708e5f094b9cd4e8f2be4f00d2f4250c4095be93f8cd6d018c753894885430"},
   "elixir_make": {:hex, :elixir_make, "0.6.2", "7dffacd77dec4c37b39af867cedaabb0b59f6a871f89722c25b28fcd4bd70530", [:mix], [], "hexpm", "03e49eadda22526a7e5279d53321d1cced6552f344ba4e03e619063de75348d9"},
 }

--- a/mix.lock
+++ b/mix.lock
@@ -1,3 +1,5 @@
 %{
+  "benchee": {:hex, :benchee, "1.0.1", "66b211f9bfd84bd97e6d1beaddf8fc2312aaabe192f776e8931cb0c16f53a521", [:mix], [{:deep_merge, "~> 1.0", [hex: :deep_merge, repo: "hexpm", optional: false]}], "hexpm", "3ad58ae787e9c7c94dd7ceda3b587ec2c64604563e049b2a0e8baafae832addb"},
+  "deep_merge": {:hex, :deep_merge, "1.0.0", "b4aa1a0d1acac393bdf38b2291af38cb1d4a52806cf7a4906f718e1feb5ee961", [:mix], [], "hexpm", "ce708e5f094b9cd4e8f2be4f00d2f4250c4095be93f8cd6d018c753894885430"},
   "elixir_make": {:hex, :elixir_make, "0.6.2", "7dffacd77dec4c37b39af867cedaabb0b59f6a871f89722c25b28fcd4bd70530", [:mix], [], "hexpm", "03e49eadda22526a7e5279d53321d1cced6552f344ba4e03e619063de75348d9"},
 }

--- a/test/mpdecimal_test.exs
+++ b/test/mpdecimal_test.exs
@@ -2,10 +2,6 @@ defmodule MPDecimalTest do
   use ExUnit.Case
   doctest MPDecimal
 
-  test "zero" do
-    assert MPDecimal.zero() == 0
-  end
-
   test "correct digit handling" do
     result = MPDecimal.Nif.power("3.14159", "1.58732")
     assert result == "6.153686306332765322891030633"

--- a/test/mpdecimal_test.exs
+++ b/test/mpdecimal_test.exs
@@ -3,6 +3,30 @@ defmodule MPDecimalTest do
   doctest MPDecimal
 
   test "zero" do
-    assert MPDecimal.zero() == 42
+    assert MPDecimal.zero() == 0
+  end
+
+  test "correct digit handling" do
+    result = MPDecimal.Nif.power("3.14159", "1.58732")
+    assert result == "6.153686306332765322891030633"
+  end
+
+  test "Strange NaN behavior???" do
+    result = MPDecimal.Nif.power("3.1", "1.587321")
+    assert result == "6.1536933506402224364507308462"
+  end
+
+  test "bad args do not crash the VM" do
+    assert_raise ArgumentError, fn ->
+      MPDecimal.Nif.power("12.34", nil)
+    end
+
+    assert_raise ArgumentError, fn ->
+      MPDecimal.Nif.power(false, "12.34")
+    end
+
+    assert_raise ArgumentError, fn ->
+      MPDecimal.Nif.power(12, 34)
+    end
   end
 end


### PR DESCRIPTION
Hey @JonnerLynx I made some progress on this after our pairing session this afternoon. In this PR I've made a few improvements like having a single static context that gets initialized when our NIF is loaded into the VM, some basic argument checking, and a benchmark so we can keep an eye on the performance of our overall solution.

I'm seeing a strange behavior though, where calling `enif_inspect_binary` creates the `ErlNifBinary` with the correct `size`, but checking `strlen(data)` shows an extra byte on the end of the string? This is resulting in mpdecimal failing to parse the strings we pass to it and producing a `NaN` result.

My guess is that we should be using the `size` attribute of the `ErlNifBinary` when parsing the string, rather than relying on null-termination? But I'm not sure how we can fix the string? Or maybe we should just be using a different function for parsing the strings?

Here are the benchmark results (with the printf's removed)

```
Operating System: macOS
CPU Information: Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
Number of Available Cores: 12
Available memory: 16 GB
Elixir 1.11.2
Erlang 23.1.1

Benchmark suite executing with the following configuration:
warmup: 2 s
time: 5 s
memory time: 0 ns
parallel: 1
inputs: none specified
Estimated total run time: 21 s

Benchmarking 2 ^ 2...
Benchmarking 2.0 ^ 2.0...
Benchmarking 3.14159 ^ 1.58732...

Name                        ips        average  deviation         median         99th %
2 ^ 2                  958.78 K        1.04 μs   ±139.90%           1 μs           2 μs
2.0 ^ 2.0              884.66 K        1.13 μs  ±1317.34%           1 μs           2 μs
3.14159 ^ 1.58732       12.32 K       81.17 μs    ±20.75%          78 μs         161 μs

Comparison: 
2 ^ 2                  958.78 K
2.0 ^ 2.0              884.66 K - 1.08x slower +0.0874 μs
3.14159 ^ 1.58732       12.32 K - 77.83x slower +80.13 μs
```