### PR TITLE
Thread safety and memory allocator configuration

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2021 Michael Ries
+Copyright (c) 2021 Michael Ries, Jonner Steck
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -1,4 +1,24 @@
 # MPDecimal
 
-An elixir wrapper around the [mpdecimal](https://www.bytereef.org/mpdecimal/) library Stefan Krah.
+An elixir wrapper around the [mpdecimal](https://www.bytereef.org/mpdecimal/) library by Stefan Krah.
 This library provides accurate fixed-precision decimal operations as a NIF.
+
+Build
+This NIF is built as a shared library, which is statically linked with the mpdecimal library.
+
+Scope
+Only the power() function is wrapped at this time, other enhancements may wrap more of the functionality of the mpdecimal library.
+
+Thread Safety
+An mpdecimal context is initialized to match the default context of the Elixir Decimal library (precision, rounding mode, traps). This context is copied for each NIF call to ensure that there is no shared mutable data, thus ensuring thread safety. All calls to the mpdecimal library are thread safe, given that no two threads use the same context.
+
+Memory
+The mpdecimal library is configured to use the memory allocator provided by the BEAM VM.
+
+Execution Time
+As a rule of thumb a well-behaving native function should return to its caller before a millisecond has passed. The power() function seems to finish in ~100 μs, so we are an order of magnitude away from needing to worry about manual execution time managment. (Breaking a single behavior into multiple function calls, or calling enif_consume_timeslice())
+
+TODOS
+- Expose more of the functionality of the mpdecimal library.
+- Test known edge cases, try to break the library, gain confidence.
+- Teach the Makefile to be agnostic to the version of the mpdecimal library that is provided in the c_lib directory.

--- a/c_src/mpdecimal_nif.c
+++ b/c_src/mpdecimal_nif.c
@@ -68,14 +68,14 @@ static void nif_debug_print_data_hex(const unsigned char* data, size_t size)
 {
   const unsigned char* end = data + size;
   while (data < end) {
-  	enif_fprintf(stdout, "0x%02x ", *(data++));
+  	printf("0x%02x ", *(data++));
   }
-  enif_fprintf(stdout, "\r\n");
+  printf("\r\n");
 }
 
 static void nif_debug_print_parameter(const char* name, const ERL_NIF_TERM* term, const ErlNifBinary* binary)
 {
-  enif_fprintf(stdout, "%s\r\n" \
+  printf(              "%s\r\n" \
                        "  raw       ", name);
   nif_debug_print_data_hex(binary->data, binary->size);
 
@@ -85,8 +85,8 @@ static void nif_debug_print_parameter(const char* name, const ERL_NIF_TERM* term
                        *term,
                        binary->size);
 
-  enif_fprintf(stdout, "  cstring   %s\r\n" \
-                       "    length  %d characters\r\n\n",
+  printf(              "  cstring   %s\r\n" \
+                       "    length  %zu characters\r\n\n",
                        binary->data,
                        strlen((char*) binary->data));
 }
@@ -121,7 +121,7 @@ static ERL_NIF_TERM mpdecimal_power(ErlNifEnv* env, int argc, const ERL_NIF_TERM
   }
 
 #ifdef NIF_DEBUG
-  enif_fprintf(stdout, "----Parameters----\r\n");
+  printf("----Parameters----\r\n");
   nif_debug_print_parameter("base", &argv[0], &base_binary);
   nif_debug_print_parameter("exp", &argv[1], &exp_binary);
 #endif
@@ -129,10 +129,6 @@ static ERL_NIF_TERM mpdecimal_power(ErlNifEnv* env, int argc, const ERL_NIF_TERM
   // Make a local copy of the previously-initialized MPD context in order to
   // make this function thread safe.
   ctx = *((mpd_context_t*) enif_priv_data(env));
-
-#ifdef NIF_DEBUG
-  printf("\r\n----MPD Parameters----\r\n");
-#endif
 
   base = mpd_new(&ctx);
   if (ctx.newtrap) {
@@ -147,21 +143,6 @@ static ERL_NIF_TERM mpdecimal_power(ErlNifEnv* env, int argc, const ERL_NIF_TERM
     return nif_make_error_tuple(env, &ctx);
   }
 
-#ifdef NIF_DEBUG
-  enif_fprintf("base      ", result_string);
-  mpd_fprint(stdout, base);
-  enif_fprintf(stdout, "\r");
-  
-  mpd_snprint_flags(status_string, MPD_MAX_FLAG_STRING, ctx->status);
-  if (strlen(status_string)) {
-    enif_fprintf(nif_debug_file, "  status  %s\r\n", status_string);
-  }
-
-  if (result_string != NULL) {
-    mpd_free(result_string);
-  }
-#endif
-
   exp = mpd_new(&ctx);
   if (ctx.newtrap) {
     mpd_del(base);
@@ -174,18 +155,6 @@ static ERL_NIF_TERM mpdecimal_power(ErlNifEnv* env, int argc, const ERL_NIF_TERM
     mpd_del(exp);
     return nif_make_error_tuple(env, &ctx);
   }
-
-#ifdef NIF_DEBUG
-  mpd_snprint_flags(status_string, MPD_MAX_FLAG_STRING, ctx->status);
-  char* result_string = mpd_to_sci(exp, 1);
-  printf("exp (mpd): %s\r\n", result_string);
-  printf("  - status: %s\r\n", status_string);
-  mpd_free(result_string);
-#endif
-
-#ifdef NIF_DEBUG
-  printf("\r\n----Perfoming Power Operation----\r\n");
-#endif
 
   result = mpd_new(&ctx);
   if (ctx.newtrap) {
@@ -202,12 +171,6 @@ static ERL_NIF_TERM mpdecimal_power(ErlNifEnv* env, int argc, const ERL_NIF_TERM
     return nif_make_error_tuple(env, &ctx);
   }
 
-#ifdef NIF_DEBUG
-  printf("result (mpd): %s\r\n", result_string);
-  mpd_snprint_flags(status_string, MPD_MAX_FLAG_STRING, ctx->status);
-  printf("  - status: %s\r\n", status_string);
-#endif
-  
   result_strlen = mpd_to_sci_size(&result_string, result, /* fmt */ 0);
   
   mpd_del(result);

--- a/lib/mpdecimal.ex
+++ b/lib/mpdecimal.ex
@@ -1,10 +1,12 @@
 defmodule MPDecimal do
   alias MPDecimal.Nif
 
-  def power(%Decimal{} = base, %Decimal{} = power) do
-    base = Decimal.to_string(base, :xsd)
-    power = Decimal.to_string(power, :xsd)
-    res = Nif.power(base, power)
-    Decimal.new(res)
+  def power(%Decimal{} = base, %Decimal{} = exponent) do
+    # Add the null terminator to the end of each string argument so that it
+    # forms a valid cstring for consumption by the NIF.
+    base = Decimal.to_string(base, :xsd) <> "\0"
+    exponent = Decimal.to_string(exponent, :xsd) <> "\0"
+    result = Nif.power(base, exponent)
+    Decimal.new(result)
   end
 end

--- a/lib/mpdecimal.ex
+++ b/lib/mpdecimal.ex
@@ -6,7 +6,15 @@ defmodule MPDecimal do
     # forms a valid cstring for consumption by the NIF.
     base = Decimal.to_string(base, :xsd) <> "\0"
     exponent = Decimal.to_string(exponent, :xsd) <> "\0"
-    result = Nif.power(base, exponent)
-    Decimal.new(result)
+    
+    case Nif.power(base, exponent) do
+      {:ok, result} -> Decimal.new(result)
+      # TODO: message should be a string, not an atom
+      {:error, message} -> raise(MPDecimal.Error, message: message)
+    end
   end
+end
+
+defmodule MPDecimal.Error do
+  defexception [:message]
 end

--- a/lib/mpdecimal.ex
+++ b/lib/mpdecimal.ex
@@ -9,7 +9,6 @@ defmodule MPDecimal do
     
     case Nif.power(base, exponent) do
       {:ok, result} -> Decimal.new(result)
-      # TODO: message should be a string, not an atom
       {:error, message} -> raise(MPDecimal.Error, message: message)
     end
   end


### PR DESCRIPTION
This PR adds support for thread safety in the mpdecimal NIF, such that multiple concurrent threads can leverage this NIF without conflict. The mpdecimal library is also configured to use the memory allocator provided by the BEAM VM (rather than the standard version of malloc() provided by the C standard library).

**Details**
Both the Elixir Decimal library and the mpdecimal library have a _context_ that defines the properties of the decimal computations to be performed (e.g. precision, rounding mode, traps). The mpdecimal library context is configured to match the properties of the default context in the Elixir Decimal library. In order to perform computations correctly, this context is passed in as a parameter to every mpdecimal library call. This introduces a potential thread safety issue if the context were to be shared, because it is mutable in the case that there is an exception during the operation. To address this issue, a shared context is initialized at NIF library load time, but this shared context is copied to the stack for every NIF call to ensure that each thread has its own unique copy of the context. This enables each thread to manipulate it's own copy of the context if an exceptional condition occurs. All possible error conditions are handled, which result in a {:error, _} tuple being returned by the NIF call. In the case of success, {:ok, _} is returned.