### PR TITLE
add stress test

### DIFF
--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -1,0 +1,38 @@
+name: Elixir CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+env:
+  MIX_ENV: test
+
+jobs:
+  build:
+
+    name: Build and test
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Elixir
+      uses: erlef/setup-beam@v1
+      with:
+        elixir-version: '1.14.4' # Define the elixir version [required]
+        otp-version: '25.3' # Define the OTP version [required]
+    - name: Install c-compiler
+      run: sudo apt-get install -y build-essential
+    - name: Restore dependencies cache
+      uses: actions/cache@v2
+      with:
+        path: deps
+        key: ${{ runner.os }}-mix-${{ hashFiles('**/mix.lock') }}
+        restore-keys: ${{ runner.os }}-mix-
+    - name: Install dependencies
+      run: mix deps.get
+    - name: Run tests
+      run: mix test
+    - name: Check Formatting
+      run: mix format --check-formatted

--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,4 @@ mpdecimal-*.tar
 
 # Temporary files for e.g. tests
 /tmp
+stress_output.txt

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ To run the stress test you can do the following:
 mix run --no-halt bench/stress_test.exs > stress_output.txt
 ```
 
-Now watch monitor the beam until it becomes idle again and check that the memory usage is flat. You can also check the contents of the `stress_output.txt` which should container the `1,000 processes * 10,000 random numbers = 10M` periods that were printed out along with a few notes like "all processes started".
+Now watch monitor the beam until it becomes idle again and check that the memory usage is flat. You can also check the contents of the `stress_output.txt` which should container the `500 processes * 40,000 random numbers = 20M` periods that were printed out along with a few notes like "processes started".
 
 > You may want to close down your editor to make sure there isn't a lanaguage server running in the background. This way you can be sure which process you're watching.
 

--- a/README.md
+++ b/README.md
@@ -24,6 +24,19 @@ The mpdecimal library is configured to use the memory allocator provided by the 
 
 As a rule of thumb a well-behaving native function should return to its caller before a millisecond has passed. The power() function seems to finish in ~100 μs, so we are an order of magnitude away from needing to worry about manual execution time managment. (Breaking a single behavior into multiple function calls, or calling enif_consume_timeslice())
 
+### Stress Test
+
+As a way of checking for memory leaks, race conditions or nif communication errors, we have created a stress test. This can be run locally while monitoring the process both with tools like observer, or with external tools like htop.
+To run the stress test you can do the following:
+
+```shell
+mix run --no-halt bench/stress_test.exs > stress_output.txt
+```
+
+Now watch monitor the beam until it becomes idle again and check that the memory usage is flat. You can also check the contents of the `stress_output.txt` which should container the `1,000 processes * 10,000 random numbers = 10M` periods that were printed out along with a few notes like "all processes started".
+
+> You may want to close down your editor to make sure there isn't a lanaguage server running in the background. This way you can be sure which process you're watching.
+
 ### TODOS
 
 * Expose more of the functionality of the mpdecimal library.

--- a/bench/stress_test.exs
+++ b/bench/stress_test.exs
@@ -1,0 +1,89 @@
+defmodule Stress do
+  def reporter do
+    receive do
+      {:decimal, _dec} ->
+        IO.write(".")
+        reporter()
+    end
+  end
+
+  # takes in numbers beteeen 1.0 and 10.0 and squares them
+  # producing numbers between 1.0 and 100.0
+  @two Decimal.new("2.0")
+  def squarer(reporters) do
+    receive do
+      {:decimal, dec} ->
+        result = MPDecimal.power(dec, @two)
+        [reporter] = Enum.take_random(reporters, 1)
+        Process.send(reporter, {:decimal, result}, [])
+        squarer(reporters)
+    end
+  end
+
+  # takes in numbers betwen 0.0 and 2.303... and produces
+  # numbers between 1.0 and 10.0
+  def expers(squarers) do
+    receive do
+      {:decimal, dec} ->
+        result = MPDecimal.exp(dec)
+        [squarer] = Enum.take_random(squarers, 1)
+        Process.send(squarer, {:decimal, result}, [])
+        expers(squarers)
+    end
+  end
+
+  # takes in numbers between 1.0 and 10.0 and produces
+  # numbers between 0 and 2.303...
+  def lners(expers) do
+    receive do
+      {:decimal, dec} ->
+        result = MPDecimal.ln(dec)
+        [exper] = Enum.take_random(expers, 1)
+        Process.send(exper, {:decimal, result}, [])
+        lners(expers)
+    end
+  end
+
+  # sends decimal numbers with values between 1.0 and 10.0
+  def feed(lners, decimals_per_process) do
+    lners
+    |> Enum.map(fn pid ->
+      Task.async(fn ->
+        (1..decimals_per_process) |> Enum.each(fn _ ->
+          float = (:rand.uniform_real() * 9.0) + 1.0
+          dec = Decimal.from_float(float)
+          Process.send(pid, {:decimal, dec}, [])
+        end)
+      end)
+    end)
+    |> Enum.map(fn task -> Task.await(task, 600_000) end)
+  end
+end
+
+
+
+reporters = Enum.map(1..1_000, fn(_i) ->
+  spawn(&Stress.reporter/0)
+end)
+
+squarers = Enum.map(1..1_000, fn(_i) ->
+  spawn(fn ->
+    Stress.squarer(reporters)
+  end)
+end)
+
+expers = Enum.map(1..1_000, fn(_i) ->
+  spawn(fn ->
+    Stress.squarer(squarers)
+  end)
+end)
+
+lners = Enum.map(1..1_000, fn(_i) ->
+  spawn(fn ->
+    Stress.squarer(expers)
+  end)
+end)
+IO.puts "processes started"
+
+Stress.feed(lners, 10_000)
+IO.puts "processes have been fed"


### PR DESCRIPTION
This PR adds a stress test that will kick of 10's of millions of decimal operations across thousands of processes and peg your CPU for a while. This should give us a good chance to validate that memory is being garbage collected and that parallel calls into the NIF won't cause problems.